### PR TITLE
Running tests with tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
   - "3.6"
-install:
-  - pip install -r requirements.txt
-script: make test
+install: pip install tox-travis==0.10
+script: tox

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 test:
-	pytest
+	tox
 
 coverage:
 	coverage run --source=sweat -m pytest --

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+# tox (https://tox.readthedocs.io/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py36
+
+[testenv]
+commands = pytest
+deps = -rrequirements.txt


### PR DESCRIPTION
For now this doesn't change anything but I want to support more Python versions in the future: I think 3.5 is the most common Python 3 version so that should be supported but I also want to get ready for 3.7.