### PR TITLE
Adds on-the-fly enabling of function argument casting

### DIFF
--- a/sweat/io/models/dataframes.py
+++ b/sweat/io/models/dataframes.py
@@ -25,7 +25,7 @@ class WorkoutDataFrame(BaseWorkoutDataFrame):
         return core.mean_max(self.power)
 
     def compute_weighted_average_power(self):
-        return core.weighted_average_power(self.power, type='WAP')
+        return core.weighted_average_power(self.power, algorithm='WAP')
 
     def compute_power_per_kg(self):
         return power.wpk(self.power, self.athlete.weight)

--- a/sweat/metrics/core.py
+++ b/sweat/metrics/core.py
@@ -1,15 +1,14 @@
 import numpy as np
 import pandas as pd
 from collections import namedtuple
-from sweat.utils import cast_array_to_original_type
 
 
-def mask_fill(arg, mask=None, value=0.0, **kwargs):
+def mask_fill(y, mask=None, value=0.0):
     """Replace masked values
 
     Parameters
     ----------
-    arg : array-like
+    y : ndarray
     mask : array-like of bools, optional
         Default value is None, which means no masking will be applied
     value : number, optional
@@ -17,28 +16,22 @@ def mask_fill(arg, mask=None, value=0.0, **kwargs):
 
     Returns
     -------
-    y: type of input argument
+    y: ndarray
 
-
-    In case the arg is an ndarray all operations will be performed on the original array.
+    All operations will be performed on the original array.
     To preserve original array pass a copy to the function
     """
 
     if mask is None:
-        return arg
-
-    y = np.array(arg)
+        return y
 
     mask = np.array(mask, dtype=bool)
     y[~mask] = value
 
-    rv = cast_array_to_original_type(y, type(arg))
-
-    return rv
+    return y
 
 
-
-def rolling_mean(arg, window=10, mask=None, value=0.0, **kwargs):
+def rolling_mean(y, window=10, mask=None, algorithm='uniform', value=0.0):
     """Compute rolling mean
 
     Compute *uniform* or *ewma* rolling mean of the stream. In-process masking with replacement is
@@ -46,46 +39,45 @@ def rolling_mean(arg, window=10, mask=None, value=0.0, **kwargs):
 
     Parameters
     ----------
-    arg : array-like
+    y : ndarray
     window : int
         Size of the moving window in sec, default=10
     mask : array-like of boolean, optional
         Default value is None, which means no masking will be applied
+    algorithm : {"uniform", "emwa"}, optional
+        Type of averaging, default="uniform"
     value : number, optional
         Value to use for replacement, default=0.0
-    type : {"uniform", "emwa"}, optional
-        Type of averaging, default="uniform"
 
     Returns
     -------
-    y: type of input argument
+    y: ndarray
 
     The moving array will indicate which samples to set to zero before
     applying rolling mean.
     """
     if mask is not None:
-        arg = mask_fill(arg, mask, value, **kwargs)
+        y = mask_fill(y, mask, value)
 
-    y = pd.Series(arg)
+    y = pd.Series(y)
 
-    if kwargs.get('type', 'uniform') == 'ewma':
+
+    if algorithm == 'ewma':
         y = y.ewm(span=window, min_periods=1).mean().values
-    else:
+    elif algorithm == 'uniform':
         y = y.rolling(window, min_periods=1).mean().values
-
-    y = cast_array_to_original_type(y, type(arg))
 
     return y
 
 
-def median_filter(arg, window=31, threshold=1, value=None, **kwargs):
+def median_filter(y, window=31, threshold=1, value=None):
     """Outlier replacement using median filter
 
     Detect outliers using median filter and replace with rolling median or specified value
 
     Parameters
     ----------
-    arg : array-like
+    y : ndarray
     window : int, optional
         Size of window (including the sample; default=31 is equal to 15 on either side of value)
     threshold : number, optional
@@ -95,12 +87,12 @@ def median_filter(arg, window=31, threshold=1, value=None, **kwargs):
 
     Returns
     -------
-    y: type of input argument
+    y: ndarray
 
-    In case the arg is an ndarray all operations will be performed on the original array.
+    All operations will be performed on the original array.
     To preserve original array pass a copy to the function
     """
-    y = pd.Series(arg)
+    y = pd.Series(y)
 
     rolling_median = y.rolling(window, min_periods=1).median()
 
@@ -118,11 +110,7 @@ def median_filter(arg, window=31, threshold=1, value=None, **kwargs):
     else:
         y[outlier_idx] = rolling_median[outlier_idx]
 
-    y = y.as_matrix()
-
-    y = cast_array_to_original_type(y, type(arg))
-
-    return y
+    return y.values
 
 
 # FTP based 7-zones with left bind edge set to -0.001
@@ -137,7 +125,7 @@ HEART_RATE_ZONES_DESC = ["Active recovery", "Endurance", "Tempo", "Threshold", "
 HEART_RATE_ZONES_ZNAME = ["Z1", "Z2", "Z3", "Z4", "Z5"]
 
 
-def compute_zones(arg, **kwargs):
+def compute_zones(y, zones=None, ftp=None, lthr=None, labels=None):
     """Convert stream into respective zones stream
 
     Watts streams can be converted either into ftp based 7-zones or into custom zones
@@ -146,7 +134,7 @@ def compute_zones(arg, **kwargs):
 
     Parameters
     ----------
-    arg : array-like
+    y : ndarray
     ftp : number, optional
         Value for FTP, will be used for 7-zones calculation
     lthr: number, optional
@@ -159,37 +147,32 @@ def compute_zones(arg, **kwargs):
     array-like of int, the same type as arg
     """
 
-    arg_s = pd.Series(arg)
-
-    if kwargs.get('zones', None):
-        abs_zones = kwargs.get('zones')
-
-    elif kwargs.get('ftp', None):
-        abs_zones = np.asarray(POWER_ZONES_THRESHOLD) * kwargs.get('ftp')
-
-    elif kwargs.get('lthr', None):
-        abs_zones = np.asarray(HEART_RATE_ZONES) * kwargs.get('lthr')
-
+    if zones is not None:
+        abs_zones = zones
+    elif ftp is not None:
+        abs_zones = np.asarray(POWER_ZONES_THRESHOLD) * ftp
+    elif lthr is not None:
+        abs_zones = np.asarray(HEART_RATE_ZONES) * lthr
     else:
-        raise ValueError
+        raise ValueError('One of the keyword arguments [zones, ftp, lthr] must be provided')
 
-    labels = kwargs.get('labels', list(range(1, len(abs_zones))))
+    if labels is None:
+        labels = list(range(1, len(abs_zones)))
     assert len(abs_zones) == (len(labels) + 1)
 
-    y = pd.cut(arg_s, bins=abs_zones, labels=labels)
-    y = cast_array_to_original_type(y, type(arg))
+    y = pd.cut(y, bins=abs_zones, labels=labels)
 
     return y
 
 
-def best_interval(arg, window, mask=None, value=0.0, **kwargs):
+def best_interval(y, window, mask=None, value=0.0):
     """Compute best interval of the stream
 
     Masking with replacement is controlled by keyword arguments
 
     Parameters
     ----------
-    arg: array-like
+    y: ndarray
     window : int
         Duration of the interval in seconds
     mask : array-like of bool, optional
@@ -202,68 +185,63 @@ def best_interval(arg, window, mask=None, value=0.0, **kwargs):
     float
     """
 
-    y = rolling_mean(arg, window=window, mask=mask, value=value, **kwargs)
+    y = rolling_mean(y, window=window, mask=mask, value=value)
 
     rv = np.max(y)
 
     return rv
 
 
-def time_in_zones(arg, **kwargs):
+def time_in_zones(y, **kwargs):
     """Time in zones
 
     Calculate time [sec] spent in each zone
 
     Parameters
     ----------
-    arg : array-like, power or heartrate
+    y : ndarray, power or heartrate
     kwargs : see zones
 
     Returns
     -------
-    array-like, the same type as arg
+    ndarray
     """
-    type_arg = type(arg)
-    z = pd.Series(compute_zones(arg, **kwargs))
+    z = pd.Series(compute_zones(y, **kwargs))
     tiz = z.groupby(z).count()
-    rv = cast_array_to_original_type(tiz, type_arg)
 
-    return rv
+    return tiz.values
 
 
-def weighted_average_power(arg, mask=None, value=0.0, **kwargs):
+def weighted_average_power(y, mask=None, algorithm='WAP', value=0.0):
     """Weighted average power
 
     Parameters
     ----------
-    arg : array-like
+    y : ndarray
         Power stream
     mask: array-like of bool, optional
         default=None, which means no masking
+    algorithm : {"WAP", "xPower"}
+        Determines calculation method to use, default='WAP'
     value : number, optional
         Value to use for replacement, default=0.0
-    type : {"WAP", "xPower"}
-        Determines calculation method to use, default='WAP'
 
     Returns
     -------
     number
     """
 
-    if kwargs.get('type', 'WAP') == 'xPower':
-        _rolling_mean = rolling_mean(arg, window=25, mask=mask, value=value, type='emwa')
-    else:
-        _rolling_mean = rolling_mean(arg, window=30, mask=mask, value=value)
-
-    if type(_rolling_mean) == list:
-        _rolling_mean = np.asarray(_rolling_mean, dtype=np.float)
+    if algorithm == 'WAP':
+        _rolling_mean = rolling_mean(y, window=30, mask=mask, value=value)
+    elif algorithm == 'xPower':
+        _rolling_mean = rolling_mean(y, window=25, mask=mask, value=value, algorithm='emwa')
 
     rv = np.mean(np.power(_rolling_mean, 4)) ** (1/4)
 
     return rv
 
 
-def mean_max(arg, mask=None, value=0.0, **kwargs):
+def mean_max(y, mask=None, value=0.0):
     """Mean-max curve
 
     Compute mean-max (power duration curve) from the stream. Mask-filter options can be
@@ -280,11 +258,10 @@ def mean_max(arg, mask=None, value=0.0, **kwargs):
 
     Returns
     -------
-    rv : type of input argument
-        Power-Duration Curve
+    ndarray
     """
 
-    y = mask_fill(arg, mask=mask, value=value)
+    y = mask_fill(y, mask=mask, value=value)
     y = pd.Series(y)
 
     # Compute the accumulated energy from the power data
@@ -295,7 +272,6 @@ def mean_max(arg, mask=None, value=0.0, **kwargs):
     y = np.array([])
     for t in np.arange(1, len(energy)):
         y = np.append(y, energy.diff(t).max()/(t))
-    y = cast_array_to_original_type(y, type(arg))
 
     return y
 
@@ -315,7 +291,7 @@ def multiple_best_intervals(arg, duration, number):
 
     Returns
     -------
-    pd.Series
+    ndarray
     """
     moving_average = arg.rolling(duration).mean()
     length = len(moving_average)
@@ -335,4 +311,4 @@ def multiple_best_intervals(arg, duration, number):
         overlap_max_index = min(length, max_index+duration)
         moving_average.loc[overlap_min_index:overlap_max_index] = np.nan
 
-    return pd.Series(mean_max_bests)
+    return mean_max_bests

--- a/sweat/metrics/power.py
+++ b/sweat/metrics/power.py
@@ -1,5 +1,4 @@
 import pandas as pd
-from sweat.utils import cast_array_to_original_type
 
 
 def wpk(power, weight):
@@ -7,7 +6,7 @@ def wpk(power, weight):
 
     Parameters
     ----------
-    power : list, ndarray, series
+    power : ndarray
     weight : number
 
     Returns
@@ -15,15 +14,7 @@ def wpk(power, weight):
     array-like
     """
 
-    if not isinstance(power, pd.Series):
-        y = pd.Series(power)
-    else:
-        y = power
-
-    rv = y/weight
-    rv = cast_array_to_original_type(rv, type(power))
-
-    return rv
+    return power/weight
 
 
 def relative_intensity(wap, threshold_power):

--- a/sweat/utils.py
+++ b/sweat/utils.py
@@ -1,31 +1,107 @@
+import functools
+import inspect
+import sys
+import types
+
 import numpy as np
 import pandas as pd
-import logging
-
-logger = logging.getLogger(__name__)
 
 
-def cast_array_to_original_type(arg, arg_type):
-    """Cast array to another array-like type
+CAST_TYPES = [list, pd.Series]
+
+
+def type_casting(func):
+    """Type casting
+    This decorator casts input arguments of types [list, pandas.Series] to numpy.ndarray
+    so the algorithms accept these input arguments.
+    As a bonus, the decorator casts the return value of the algorithm to the type of the first
+    array-like input argument.
 
     Parameters
     ----------
-    arg: array-like {list, ndarray, pd.Series}
-    arg_type: type
+    module_or_func : [types.ModuleType, types.FunctionType]
+        Module or function that has to be type casted. Can be None.
 
     Returns
     -------
-    casted : arg_type array-like
+    function
+        Decorated function.
     """
+    @functools.wraps(func)
+    def func_wrapper(*args, **kwargs):
+        output_type = None
+        new_args = []
 
-    if arg_type == list:
-        return list(arg)
+        for arg in args:
+            input_type = type(arg)
 
-    elif arg_type == np.ndarray:
-        return np.array(arg)
+            if input_type in CAST_TYPES:
+                new_args.append(np.asarray(arg))
 
-    elif arg_type == pd.Series:
-        return pd.Series(arg)
+                if output_type is None:
+                    # Type of first array-like argument is used for output casting
+                    output_type = input_type
+            else:
+                new_args.append(arg)
+
+        # There is no use-case for type casting kwargs now.
+        # If there is, this can be uncommented and tests can be added.
+        # new_kwargs = dict()
+        # for key, value in kwargs.items():
+        #     input_type = type(value)
+
+        #     if input_type in CAST_TYPES:
+        #         new_kwargs[key] = np.asarray(value)
+
+        #         if output_type is None:
+        #             # Type of first array-like argument is used for output casting
+        #             output_type = input_type
+        #     else:
+        #         new_kwargs[key] = value
+        # 
+        # output = func(*new_args, **new_kwargs)
+
+        output = func(*new_args)
+        if output_type is not None and isinstance(output, np.ndarray):
+            return output_type(output)
+        else:
+            return output
+
+    return func_wrapper
+
+
+def enable_type_casting(module_or_func=None):
+    """Enable type casting
+    This method enables casting of input arguments to numpy.ndarray so the algorithms accept
+    array-like input arguments of types list and pandas.Series.
+    As a bonus, the return value of the algorithm is casted to the type of the first array-like input argument.
+
+    Parameters
+    ----------
+    module_or_func : [types.ModuleType, types.FunctionType]
+        Module or function that has to be type casted. Can be None.
+
+    Returns
+    -------
+    function
+        Decorated function.
+    """
+    if module_or_func is None:
+        # Because sys.modules changes during this operation we cannot loop over sys.modules directly
+        key_values = [(key, value) for key, value in sys.modules.items()]
+        for key, value in key_values:
+            # @TODO this if statement might not cover all cases (or too much cases)
+            if key.startswith('sweat.hrm') or key.startswith('sweat.pdm') or key.startswith('sweat.metrics'):
+                enable_type_casting(module_or_func=value)
+
+    elif isinstance(module_or_func, types.ModuleType):
+        for name, obj in [(name, obj) for name, obj in inspect.getmembers(module_or_func)]:
+            if inspect.isfunction(obj) and inspect.getmodule(obj).__package__ == module_or_func.__package__:
+                func = getattr(module_or_func, name)
+                setattr(module_or_func, name, type_casting(func))
+
+    elif isinstance(module_or_func, types.FunctionType):
+        return type_casting(module_or_func)
 
     else:
-        raise ValueError("arg_type must be list, ndarray or pd.Series")
+        raise ValueError('enable_type_casting takes arguments of types [ModuleType, FunctionType]')

--- a/tests/io/models/test_models.py
+++ b/tests/io/models/test_models.py
@@ -109,8 +109,8 @@ class TestWorkoutDataFrame:
     def test_compute_mean_max_power(self, wdf_big):
         mmp = wdf_big.compute_mean_max_power()
 
-        assert mmp.iloc[1] == 263.0
-        assert mmp.iloc[300] == 209.37209302325581
+        assert mmp[1] == 263.0
+        assert mmp[300] == 209.37209302325581
 
     def test_compute_weighted_average_power(self, wdf_big):
         assert wdf_big.compute_weighted_average_power() == pytest.approx(156.24624656343036, 0.1)

--- a/tests/metrics/test_core.py
+++ b/tests/metrics/test_core.py
@@ -13,90 +13,66 @@ class TestMaskFill():
 
     def test_mask_fill_no_mask(self):
 
-        arg = [1, 1, 1]
-        expected = [1, 1, 1]
+        arg = np.asarray([1, 1, 1])
+        expected = np.asarray([1, 1, 1])
 
         rv = mask_fill(arg)
-        assert type(rv) == list
-        assert rv == expected
+        assert (rv == expected).all()
 
 
     def test_mask_fill(self):
 
-        arg = [1, 1, 1]
+        arg = np.asarray([1, 1, 1])
         mask = [True, False, True]
-        expected = [1, 3.0, 1]
+        expected = np.asarray([1, 3.0, 1])
 
         rv = mask_fill(arg, mask=mask, value=3.0)
-        assert type(rv) == list
-        assert rv == expected
+        assert (rv == expected).all()
 
         arg = np.array([1, 1, 1])
         mask = [True, False, True]
         expected = np.array([1, 3.0, 1])
 
         rv = mask_fill(arg, mask=mask, value=3.0)
-        assert type(rv) == np.ndarray
         assert (rv == expected).all()
 
 
 class TestRollingMean():
 
-    def test_rolling_mean_ndarray(self):
+    def test_rolling_mean(self):
         stream = np.asarray([1, 2, 3, 4, 5])
         expected = np.asarray([1, 1.5, 2.5, 3.5, 4.5])
 
         rv = rolling_mean(stream, 2)
 
-        assert type(rv) == np.ndarray
         assert (rv == expected).all()
 
 
-    def test_rolling_mean_list(self):
-        stream = [1, 2, 3, 4, 5]
-        expected = [1, 1.5, 2.5, 3.5, 4.5]
-        rv = rolling_mean(stream, 2)
-
-        assert type(rv) == list
-        assert rv == expected
-
-
-    def test_rolling_mean_list_with_mask(self):
-        stream = [1, 2, 3, 4, 5]
-        mask = [True, True, False, True, True]
-        expected = [1, 1.5, 1.0, 2.0, 4.5]
-        rv = rolling_mean(stream, window=2, mask=mask)
-
-        assert type(rv) == list
-        assert rv == expected
-
-
-    def test_rolling_mean_with_mask_ndarray(self):
+    def test_rolling_mean_with_mask(self):
         stream = np.asarray([1, 2, 3, 4, 5])
         mask = np.asarray([True, True, False, True, True], dtype=bool)
         expected = np.asarray([1, 1.5, 1.0, 2.0, 4.5])
         rv = rolling_mean(stream, window=2, mask=mask)
 
-        assert type(rv) == np.ndarray
         assert (rv == expected).all()
 
 
     def test_rolling_mean_list_emwa(self):
-        stream = list(np.ones(30))
-        expected = list(np.ones(30))
-        rv = rolling_mean(stream, 2, type='ewma')
+        stream = np.ones(30)
+        expected = np.ones(30)
+        rv = rolling_mean(stream, 2, algorithm='ewma')
 
-        assert type(rv) == list
-        assert rv == expected
+        assert (rv == expected).all()
 
 
     def test_rolling_mean_real_data(self, test_stream):
-        rv = rolling_mean(test_stream['watts'],
-                                  mask=test_stream['moving'],
-                                  window=1)
+        rv = rolling_mean(
+            np.asarray(test_stream['watts']),
+            mask=test_stream['moving'],
+            window=1
+        )
 
-        assert type(rv) == list
-        assert rv == test_stream['watts']
+        assert (rv == test_stream['watts']).all()
 
 
 class TestMedianFilter():
@@ -106,22 +82,7 @@ class TestMedianFilter():
         stream[-1] = 2
 
         rv = median_filter(stream)
-        assert type(rv) == np.ndarray
         assert (rv == np.ones(60)).all()
-
-
-    def test_median_filter_list(self):
-        stream = np.ones(60)
-        stream[-1] = 2
-        stream = stream.tolist()
-
-        expected = np.ones(60)
-        expected = expected.tolist()
-
-        rv = median_filter(stream)
-
-        assert type(rv) == list
-        assert rv == expected
 
 
     def test_median_filter_with_replacement(self):
@@ -133,82 +94,50 @@ class TestMedianFilter():
 
         rv = median_filter(stream, value=10)
 
-        assert type(rv) == np.ndarray
         assert (rv == expected).all()
 
 
 class TestComputeZones():
-
-    def test_zones_power_ftp_list(self):
-        stream = [0.55, 0.75, 0.9, 1.05, 1.2, 1.5, 10.0]
-        expected = [1, 2, 3, 4, 5, 6, 7]
-
-        rv = compute_zones(stream, ftp=1.0)
-
-        assert type(rv) == list
-        assert rv == expected
-
-
-    def test_zones_heart_rate_lthr_list(self):
-        stream = [0.6, 0.8, 0.9, 1.0, 1.1]
-        expected = [1, 2, 3, 4, 5]
-
-        rv = compute_zones(stream, lthr=1.0)
-
-        assert type(rv) == list
-        assert rv == expected
-
-
-    def test_zones_power_explicit_zones_list(self):
-        stream = [1, 150, 210, 250, 300, 350, 450]
-        expected = [1, 2, 3, 4, 5, 6, 7]
-
-        rv = compute_zones(stream, zones=[-1, 144, 196, 235, 274, 313, 391, 10000])
-
-        assert type(rv) == list
-        assert rv == expected
-
-
-    def test_zones_heart_rate_explicit_zones_list(self):
-        stream = [60, 120, 150, 160, 170, 180]
-        expected = [1, 1, 2, 3, 4, 5]
-
-        rv = compute_zones(stream, zones=[-1, 142, 155, 162, 174, 10000])
-
-        assert type(rv) == list
-        assert rv == expected
-
-
-    def test_zones_power_ftp_list_of_int(self):
-        stream = [1, 2, ]
-        ftp = 1.0
-        expected = [4, 7, ]
-
-        rv = compute_zones(stream, ftp=ftp)
-
-        assert type(rv) == list
-        assert rv == expected
-
-
-    def test_zones_power_ftp_unordered_list(self):
-        stream = [2, 1, 3]
-        ftp = 1.0
-        expected = [7, 4, 7, ]
-
-        rv = compute_zones(stream, ftp=ftp)
-
-        assert type(rv) == list
-        assert rv == expected
-
-
-    def test_zones_power_ftp_ndarray(self):
+    def test_zones_power_ftp(self):
         stream = np.asarray([0.55, 0.75, 0.9, 1.05, 1.2, 1.5, 10.0])
         expected = np.asarray(list(range(1, 8)))
 
         rv = compute_zones(stream, ftp=1.0)
 
-        assert type(rv) == np.ndarray
         assert (rv == expected).all()
+
+
+    def test_zones_heart_rate_lthr(self):
+        stream = np.asarray([0.6, 0.8, 0.9, 1.0, 1.1])
+        expected = np.asarray([1, 2, 3, 4, 5])
+
+        rv = compute_zones(stream, lthr=1.0)
+
+        assert (rv == expected).all()
+
+
+    def test_zones_power_explicit_zones(self):
+        stream = np.asarray([1, 150, 210, 250, 300, 350, 450])
+        expected = np.asarray([1, 2, 3, 4, 5, 6, 7])
+
+        rv = compute_zones(stream, zones=[-1, 144, 196, 235, 274, 313, 391, 10000])
+
+        assert (rv == expected).all()
+
+
+    def test_zones_heart_rate_explicit_zones(self):
+        stream = np.asarray([60, 120, 150, 160, 170, 180])
+        expected = np.asarray([1, 1, 2, 3, 4, 5])
+
+        rv = compute_zones(stream, zones=[-1, 142, 155, 162, 174, 10000])
+
+        assert (rv == expected).all()
+
+    def test_zones_invalid(self):
+        stream = np.asarray([60, 120, 150, 160, 170, 180])
+
+        with pytest.raises(ValueError):
+            compute_zones(stream)
 
 
 class TestBestInterval():
@@ -229,10 +158,9 @@ class TestTimeInZones():
         zones.return_value = [1, 2, 3, 4, 5, 6, 7]
 
         rv = time_in_zones(power, ftp=1.0)
-        expected = [1, 1, 1, 1, 1, 1, 1]
+        expected = np.asarray([1, 1, 1, 1, 1, 1, 1])
 
-        assert type(rv) == list
-        assert rv == expected
+        assert (rv == expected).all()
 
 
 class TestWeightedAveragePower():
@@ -248,7 +176,7 @@ class TestWeightedAveragePower():
         stream = np.ones(30)
         moving = np.ones(30, dtype=bool)
 
-        assert weighted_average_power(stream, moving, type='xPower') == 1
+        assert weighted_average_power(stream, moving, algorithm='xPower') == 1
 
 
 class TestMeanMax():
@@ -257,40 +185,9 @@ class TestMeanMax():
         power = np.arange(101)
         rv = mean_max(power)
 
-        assert type(power) == np.ndarray
         assert rv[0] == 100.0
         assert rv[49] == 75.5
         assert rv[-1] == 50.5
-
-
-    def test_power_duration_curve_list(self):
-        stream = [0, 0, 0]
-        expected = [0, 0]
-
-        rv = mean_max(stream)
-
-        assert type(rv) == list
-        assert rv == expected
-
-
-    def test_power_duration_curve_ndarray(self):
-        stream = np.zeros(3)
-        expected = np.zeros(2)
-
-        rv = mean_max(stream)
-
-        assert type(rv) == np.ndarray
-        assert (rv == expected).all()
-
-
-    def test_power_duration_curve_series(self):
-        stream = pd.Series(np.zeros(3))
-        expected = pd.Series(np.zeros(2))
-
-        rv = mean_max(stream)
-
-        assert type(rv) == pd.Series
-        assert (rv == expected).all()
 
 
 class TestMultipleBestIntervals():
@@ -299,7 +196,6 @@ class TestMultipleBestIntervals():
         bests = multiple_best_intervals(power, 3, 3)
 
         assert len(bests) == 3
-        assert isinstance(bests[0], DataPoint)
         assert bests[0].index == 99
         assert bests[0].value == 98.0
         assert bests[2].index == 91

--- a/tests/metrics/test_power.py
+++ b/tests/metrics/test_power.py
@@ -9,19 +9,9 @@ def test_wpk():
     power = [1,2,3]
     weight = 2
 
-    rv = wpk(power, weight)
-    expected = [0.5,1.0,1.5]
-    assert type(rv) == list
-    assert rv == expected
-
     rv = wpk(np.array(power), weight)
     expected = np.array([0.5, 1.0, 1.5])
     assert type(rv) == np.ndarray
-    assert (rv == expected).all()
-
-    rv = wpk(pd.Series(power), weight)
-    expected = pd.Series([0.5, 1.0, 1.5])
-    assert type(rv) == pd.Series
     assert (rv == expected).all()
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,30 +1,108 @@
+import importlib
+import sys
+
 import numpy as np
 import pandas as pd
-from sweat.utils import cast_array_to_original_type
+import pytest
+
+from sweat import utils
+from sweat.metrics import power
 
 
-def test_cast_array_to_original_type():
+@pytest.fixture()
+def reload_power_module():
+    yield
+    key_values = [(key, value) for key, value in sys.modules.items()]
+    for key, value in key_values:
+        if key.startswith('sweat.hrm') or key.startswith('sweat.pdm') or key.startswith('sweat.metrics'):
+            importlib.reload(value)
 
-    arg = [0, 0, 0]
 
-    rv = cast_array_to_original_type(np.array(arg), type(arg))
-    assert type(rv) == type(arg)
+def test_enable_type_casting_module(reload_power_module):
+    pwr = [1, 2, 3]
+    wap = [1, 2, 3]
+    weight = 80
+    threshold_power = 80
 
-    rv = cast_array_to_original_type(pd.Series(arg), type(arg))
-    assert type(rv) == type(arg)
+    assert isinstance(power.wpk(np.asarray(pwr), weight), np.ndarray)
+    assert isinstance(power.relative_intensity(np.asarray(wap), threshold_power), np.ndarray)
 
-    arg = np.array([0, 0, 0])
+    with pytest.raises(TypeError):
+        power.wpk(pwr, weight)
 
-    rv = cast_array_to_original_type(list(arg), type(arg))
-    assert type(rv) == type(arg)
+    with pytest.raises(TypeError):
+        power.relative_intensity(wap, threshold_power)
+    
+    doc_string = power.wpk.__doc__
+    utils.enable_type_casting(power)
 
-    rv = cast_array_to_original_type(pd.Series(arg), type(arg))
-    assert type(rv) == type(arg)
+    assert isinstance(power.wpk(pwr, weight), list)
+    assert isinstance(power.wpk(pd.Series(pwr), weight), pd.Series)
+    assert isinstance(power.wpk(np.asarray(pwr), weight), np.ndarray)
 
-    arg = pd.Series([0, 0, 0])
+    assert isinstance(power.relative_intensity(wap, threshold_power), list)
+    assert isinstance(power.relative_intensity(pd.Series(wap), threshold_power), pd.Series)
+    assert isinstance(power.relative_intensity(np.asarray(wap), threshold_power), np.ndarray)
 
-    rv = cast_array_to_original_type(list(arg), type(arg))
-    assert type(rv) == type(arg)
+    assert power.wpk.__doc__ == doc_string
 
-    rv = cast_array_to_original_type(np.array(arg), type(arg))
-    assert type(rv) == type(arg)
+def test_enable_type_casting_func(reload_power_module):
+    pwr = [1, 2, 3]
+    wap = [1, 2, 3]
+    weight = 80
+    threshold_power = 80
+
+    assert isinstance(power.wpk(np.asarray(pwr), weight), np.ndarray)
+    assert isinstance(power.relative_intensity(np.asarray(wap), threshold_power), np.ndarray)
+
+    with pytest.raises(TypeError):
+        power.wpk(pwr, weight)
+
+    with pytest.raises(TypeError):
+        power.relative_intensity(wap, threshold_power)
+    
+    doc_string = power.wpk.__doc__
+    wpk = utils.enable_type_casting(power.wpk)
+
+    assert isinstance(wpk(pwr, weight), list)
+    assert isinstance(wpk(pd.Series(pwr), weight), pd.Series)
+    assert isinstance(wpk(np.asarray(pwr), weight), np.ndarray)
+
+    with pytest.raises(TypeError):
+        power.relative_intensity(wap, threshold_power)
+
+    assert power.wpk.__doc__ == doc_string
+
+
+def test_enable_type_casting_all(reload_power_module):
+    pwr = [1, 2, 3]
+    wap = [1, 2, 3]
+    weight = 80
+    threshold_power = 80
+
+    assert isinstance(power.wpk(np.asarray(pwr), weight), np.ndarray)
+    assert isinstance(power.relative_intensity(np.asarray(wap), threshold_power), np.ndarray)
+
+    with pytest.raises(TypeError):
+        power.wpk(pwr, weight)
+
+    with pytest.raises(TypeError):
+        power.relative_intensity(wap, threshold_power)
+    
+    doc_string = power.wpk.__doc__
+    utils.enable_type_casting()
+
+    assert isinstance(power.wpk(pwr, weight), list)
+    assert isinstance(power.wpk(pd.Series(pwr), weight), pd.Series)
+    assert isinstance(power.wpk(np.asarray(pwr), weight), np.ndarray)
+
+    assert isinstance(power.relative_intensity(wap, threshold_power), list)
+    assert isinstance(power.relative_intensity(pd.Series(wap), threshold_power), pd.Series)
+    assert isinstance(power.relative_intensity(np.asarray(wap), threshold_power), np.ndarray)
+
+    assert power.wpk.__doc__ == doc_string
+
+
+def test_enable_type_casting_error():
+    with pytest.raises(ValueError):
+        utils.enable_type_casting('covfefe')


### PR DESCRIPTION
Unittests should make clear how it can be used.
I don't necessarily like the implementation (not very transparent to the end user what's happening and it's not very Pythonic) but I realize it serves a purpose for some use-cases. From that perspective I like this approach way more than `if isinstance(..) then` logic in every algorithm.